### PR TITLE
Starting to add Getters, Setters, and Allocators to the C interface

### DIFF
--- a/include/ntcore_c.h
+++ b/include/ntcore_c.h
@@ -339,7 +339,12 @@ void NT_DisposeString(struct NT_String *str);
 /* sets length to zero and pointer to null */
 void NT_InitString(struct NT_String *str);
 
+/* Gets the type for the specified key, or unassigned if non existent. */
+enum NT_Type NT_GetType(const char *name, size_t name_len);
+
 void NT_DisposeConnectionInfoArray(struct NT_ConnectionInfo *arr, size_t count);
+
+void NT_DisposeEntryInfoArray(struct NT_EntryInfo *arr, size_t count);
 
 void NT_DisposeRpcDefinition(struct NT_RpcDefinition *def);
 
@@ -352,6 +357,63 @@ unsigned long long NT_Now(void);
 typedef void (*NT_LogFunc)(unsigned int level, const char *file,
                            unsigned int line, const char *msg);
 void NT_SetLogger(NT_LogFunc func, unsigned int min_level);
+
+/*
+Interop Utility Functions
+*/
+
+/* Memory Allocators */
+char *NT_AllocateCharArray(size_t size);
+
+double *NT_AllocateDoubleArray(size_t size);
+
+int *NT_AllocateBooleanArray(size_t size);
+
+struct NT_String *NT_AllocateNTStringArray(size_t size);
+
+struct NT_String NT_AllocateNTString(size_t size);
+
+void NT_FreeDoubleArray(double *v_double);
+void NT_FreeBooleanArray(int *v_boolean);
+void NT_FreeStringArray(struct NT_String *v_string, size_t arr_size);
+
+enum NT_Type NT_GetTypeFromValue(struct NT_Value *value);
+
+int NT_GetEntryBooleanFromValue(struct NT_Value *value, unsigned long long *last_change, int *v_boolean);
+int NT_GetEntryDoubleFromValue(struct NT_Value *value, unsigned long long *last_change, double *v_double);
+int NT_GetEntryStringFromValue(struct NT_Value *value, unsigned long long *last_change, struct NT_String *v_string);
+int NT_GetEntryRawFromValue(struct NT_Value *value, unsigned long long *last_change, struct NT_String *v_raw);
+
+int *NT_GetEntryBooleanArrayFromValue(struct NT_Value *value, unsigned long long *last_change, size_t *arr_size);
+double *NT_GetEntryDoubleArrayFromValue(struct NT_Value *value, unsigned long long *last_change, size_t *arr_size);
+NT_String *NT_GetEntryStringArrayFromValue(struct NT_Value *value, unsigned long long *last_change, size_t *arr_size);
+
+
+int NT_GetEntryBoolean(const char* name, size_t name_len, unsigned long long *last_change, int *v_boolean);
+int NT_GetEntryDouble(const char* name, size_t name_len, unsigned long long *last_change, double *v_double);
+int NT_GetEntryString(const char *name, size_t name_len, unsigned long long *last_change, struct NT_String *v_string);
+int NT_GetEntryRaw(const char *name, size_t name_len, unsigned long long *last_change, struct NT_String *v_raw);
+
+int *NT_GetEntryBooleanArray(const char* name, size_t name_len, unsigned long long *last_change, size_t *arr_size);
+double *NT_GetEntryDoubleArray(const char* name, size_t name_len, unsigned long long *last_change, size_t *arr_size);
+NT_String *NT_GetEntryStringArray(const char* name, size_t name_len, unsigned long long *last_change, size_t *arr_size);
+
+/* Entry Value Setters */
+int NT_SetEntryDouble(const char *name, size_t name_len,
+  double v_double, int force);
+int NT_SetEntryBoolean(const char *name, size_t name_len,
+  int v_boolean, int force);
+int NT_SetEntryString(const char *name, size_t name_len,
+  struct NT_String v_string, int force);
+int NT_SetEntryRaw(const char *name, size_t name_len,
+  struct NT_String v_raw, int force);
+
+int NT_SetEntryBooleanArray(const char *name, size_t name_len,
+  const int *arr, size_t size, int force);
+int NT_SetEntryDoubleArray(const char *name, size_t name_len,
+  const double *arr, size_t size, int force);
+int NT_SetEntryNTStringArray(const char *name, size_t name_len,
+  const struct NT_String *arr, size_t size, int force);
 
 #ifdef __cplusplus
 }

--- a/ntcore.def
+++ b/ntcore.def
@@ -41,6 +41,38 @@ NT_PackRpcValues @42
 NT_UnpackRpcValues @43
 NT_DisposeRpcDefinition @44
 NT_DisposeRpcCallInfo @45
+NT_GetType @46
+NT_AllocateDoubleArray @47
+NT_AllocateBooleanArray @48
+NT_AllocateNTStringArray @49
+NT_AllocateNTString @50
+NT_FreeDoubleArray @51
+NT_FreeBooleanArray @52
+NT_FreeStringArray @53
+NT_GetTypeFromValue @54
+NT_GetEntryBooleanFromValue @55
+NT_GetEntryDoubleFromValue @56
+NT_GetEntryStringFromValue @57
+NT_GetEntryRawFromValue @58
+NT_GetEntryBooleanArrayFromValue @59
+NT_GetEntryDoubleArrayFromValue @60
+NT_GetEntryStringArrayFromValue @61
+NT_GetEntryBoolean @62
+NT_GetEntryDouble @63
+NT_GetEntryString @64
+NT_GetEntryRaw @65
+NT_GetEntryBooleanArray @66
+NT_GetEntryDoubleArray @67
+NT_GetEntryStringArray @68
+NT_SetEntryDouble @69
+NT_SetEntryBoolean @70
+NT_SetEntryString @71
+NT_SetEntryRaw @72
+NT_SetEntryBooleanArray @73
+NT_SetEntryDoubleArray @74
+NT_SetEntryNTStringArray @75
+NT_DisposeEntryInfoArray @76
+NT_AllocateCharArray @77
 
 ; JNI functions
 JNI_OnLoad


### PR DESCRIPTION
Because of the union in the NT_Value structure, some languages would
have a difficult time with the interop. This commit adds individual
getters and setters to the C interface to make interop easier.

In addition, some languages cannot allocate native memory in the same
heap that the C code would use. This adds allocation functions to make
sure that all our memory is allocated and can be freed properly from the
same heap.

The reason the getters are not individual get functions are because that
would require the calling code to first get the type, and then call the
specific getter for that type. Doing combined get functions causes
interop code to only have to cross interop boundaries once to get the
value instead of twice, for a light performance increase. However, this
could be changed without much work.

This pull request is not complete. I plan on adding comments, and moving the functions to better locations in the file. However I wanted to get opinions on how the interface looks, and on if the actual C code is even properly written. This is the most C code I've ever written, and want to make sure I'm not doing it the completely wrong way.
