### PR TITLE
Fixed Gradle build to actually export proper functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,10 @@ model {
                 }
                 eachPlatform {
                     cppCompiler.withArguments { args ->
-                        args << '/EHsc' << '/DNOMINMAX' << '/D_SCL_SECURE_NO_WARNINGS' << '/DEF:ntcore.def'
+                        args << '/EHsc' << '/DNOMINMAX' << '/D_SCL_SECURE_NO_WARNINGS'
+                    }
+                    linker.withArguments { args ->
+                        args << '/DEF:ntcore.def'
                     }
                 }
             }
@@ -100,10 +103,10 @@ model {
                     }
                     exportedHeaders {
                         srcDirs = ["include"]
+                        includes = ["**/*.h"]
                     }
                 }
             }
         }
     }
 }
-

--- a/ntcore.def
+++ b/ntcore.def
@@ -32,7 +32,7 @@ NT_SetLogger @33
 NT_CreateRpc @34
 NT_CreatePolledRpc @35
 NT_PollRpc @36
-NT_PostRpcRepsonse @37
+NT_PostRpcResponse @37
 NT_CallRpc @38
 NT_GetRpcResult @39
 NT_PackRpcDefinition @40


### PR DESCRIPTION
I forgot to set the linker to have the .defs file, and set it on just the compiler. This fixes that. It also fixes the incorrect spelling in the ntcore.defs file.
