### PR TITLE
Adds StopNotifier and StopRpcServer functions

### DIFF
--- a/include/ntcore_c.h
+++ b/include/ntcore_c.h
@@ -350,6 +350,16 @@ void NT_StartClient(const char *server_name, unsigned int port);
 */
 void NT_StopClient(void);
 
+/** Stop Rpc Server
+ * Stops the Rpc server if it is running.
+*/
+void NT_StopRpcServer(void);
+
+/** Stop Notifier
+ * Stops the Notifier (Entry and Connection Listener) thread if it is running.
+*/
+void NT_StopNotifier(void);
+
 /** Set Update Rate
  * Sets the update rate of the table
  *

--- a/include/ntcore_cpp.h
+++ b/include/ntcore_cpp.h
@@ -229,6 +229,8 @@ void StartServer(StringRef persist_filename, const char* listen_address,
 void StopServer();
 void StartClient(const char* server_name, unsigned int port);
 void StopClient();
+void StopRpcServer();
+void StopNotifier();
 void SetUpdateRate(double interval);
 std::vector<ConnectionInfo> GetConnections();
 

--- a/ntcore.def
+++ b/ntcore.def
@@ -74,6 +74,8 @@ NT_DisposeEntryInfoArray @76
 NT_AllocateCharArray @77
 NT_FreeCharArray @78
 NT_NotifierDestroyed @79
+NT_StopRpcServer @80
+NT_StopNotifier @81
 
 ; JNI functions
 JNI_OnLoad

--- a/src/ntcore_c.cpp
+++ b/src/ntcore_c.cpp
@@ -333,6 +333,14 @@ void NT_StopClient(void) {
   nt::StopClient();
 }
 
+void NT_StopRpcServer(void) {
+  nt::StopRpcServer();
+}
+
+void NT_StopNotifier(void) {
+  nt::StopNotifier();
+}
+
 void NT_SetUpdateRate(double interval) {
   nt::SetUpdateRate(interval);
 }

--- a/src/ntcore_cpp.cpp
+++ b/src/ntcore_cpp.cpp
@@ -230,6 +230,14 @@ void StopClient() {
   Dispatcher::GetInstance().Stop();
 }
 
+void StopRpcServer() {
+  RpcServer::GetInstance().Stop();
+}
+
+void StopNotifier() {
+  Notifier::GetInstance().Stop();
+}
+
 void SetUpdateRate(double interval) {
   Dispatcher::GetInstance().SetUpdateRate(interval);
 }


### PR DESCRIPTION
Workaround for #30.  Allows libraries to shut down the secondary
threads.
