### PR TITLE
Fixes ContainsKey

### DIFF
--- a/src/networktables/NetworkTable.cpp
+++ b/src/networktables/NetworkTable.cpp
@@ -207,7 +207,7 @@ bool NetworkTable::ContainsKey(StringRef key) const {
   llvm::SmallString<128> path(m_path);
   path += PATH_SEPARATOR_CHAR;
   path += key;
-  return !nt::GetEntryValue(path);
+  return nt::GetEntryValue(path) != nullptr;
 }
 
 bool NetworkTable::ContainsSubTable(StringRef key) const {


### PR DESCRIPTION
Since C++11, `shared_ptr` has an explicit `operator bool` and thus can't be implicitly converted. The result is a `ContainsKey` which always returns `false`.

This fixes it by explicitly checking against `nullptr`.
