### PR TITLE
Load ntcore from path if extracted load fails

### DIFF
--- a/java/src/edu/wpi/first/wpilibj/networktables/NetworkTablesJNI.java
+++ b/java/src/edu/wpi/first/wpilibj/networktables/NetworkTablesJNI.java
@@ -51,8 +51,11 @@ public class NetworkTablesJNI {
             os.close();
             is.close();
           }
-
-          System.load(jniLibrary.getAbsolutePath());
+          try {
+            System.load(jniLibrary.getAbsolutePath());
+          } catch (UnsatisfiedLinkError e) {
+            System.loadLibrary("ntcore");
+          }
         } else {
           System.loadLibrary("ntcore");
         }


### PR DESCRIPTION
There's a lot of buzz going around the internet about people trying to
get ntcore working on other devices. One of the things that makes it
harder is having to have a separate jar for each platform. What this
change does is if the loading of the extracted library fails, it will
attempt to load ntcore from the path. This means that a program like
GRIP can just provide the libntcore.so and not have to worry about
compiling different jars for different platforms, and instead just provide different platforms. There might be a better workaround for future seasons, but for now this should help make things easier.
