### PR TITLE
Adds extended Remote Connection Listener

### DIFF
--- a/java/src/edu/wpi/first/wpilibj/networktables/NetworkTable.java
+++ b/java/src/edu/wpi/first/wpilibj/networktables/NetworkTable.java
@@ -214,9 +214,9 @@ public class NetworkTable implements ITable, IRemote {
 
     public void apply(int uid, boolean connected, ConnectionInfo conn) {
       if (connected)
-        targetListener.connected(targetSource);
+        targetListener.connectedEx(targetSource, conn);
       else
-        targetListener.disconnected(targetSource);
+        targetListener.disconnectedEx(targetSource, conn);
     }
   }
 

--- a/java/src/edu/wpi/first/wpilibj/tables/IRemoteConnectionListener.java
+++ b/java/src/edu/wpi/first/wpilibj/tables/IRemoteConnectionListener.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.wpilibj.tables;
 
+import edu.wpi.first.wpilibj.networktables.ConnectionInfo;
+
 /**
  * A listener that listens for connection changes in a {@link IRemote} object
  * 
@@ -17,4 +19,22 @@ public interface IRemoteConnectionListener {
 	 * @param remote the object that disconnected
 	 */
 	public void disconnected(IRemote remote);
+	/**
+	 * Extended version of connected called when an IRemote is connected.
+ 	 * Contains the connection info of the connected remote
+	 * @param remote the object that connected
+	 * @param info the connection info for the connected remote
+	 */
+	default public void connectedEx(IRemote remote, ConnectionInfo info) {
+		connected(remote);
+	}
+	/**
+	 * Extended version of connected called when an IRemote is disconnected.
+	 * Contains the connection info of the disconnected remote
+	 * @param remote the object that disconnected
+	 * @param info the connection info for the disconnected remote
+	 */
+	default public void disconnectedEx(IRemote remote, ConnectionInfo info) {
+		disconnected(remote);
+	}
 }


### PR DESCRIPTION
Since we now get ConnectionInfo when setting a connection listener,
there is some good information in there that teams could use.
Implemented using default interface methods, so teams should see no
change if they don't implement the Ex methods.

I noticed that the connection listener methods don't exist at all in
C++, so they did not get added there.

Sorry about the 2 extra commits. My master was based off of gerrit, which has those 2 commits.
