### PR TITLE
Adds SetDefault methods to NetworkTables

### DIFF
--- a/include/networktables/NetworkTable.h
+++ b/include/networktables/NetworkTable.h
@@ -267,6 +267,14 @@ class NetworkTable : public ITable {
    * @return False if the table key already exists with a different type
    */
   bool PutNumber(llvm::StringRef key, double value) override;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultNumber(llvm::StringRef key, double defaultValue) override;
 
   /**
    * Gets the number associated with the given name.
@@ -301,6 +309,15 @@ class NetworkTable : public ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutString(llvm::StringRef key, llvm::StringRef value) override;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultString(llvm::StringRef key, 
+                                llvm::StringRef defaultValue) override;
 
   /**
    * Gets the string associated with the given name.
@@ -336,6 +353,14 @@ class NetworkTable : public ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutBoolean(llvm::StringRef key, bool value) override;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultBoolean(llvm::StringRef key, bool defaultValue) override;
 
   /**
    * Gets the boolean associated with the given name.
@@ -376,6 +401,15 @@ class NetworkTable : public ITable {
   virtual bool PutBooleanArray(llvm::StringRef key,
                                llvm::ArrayRef<int> value) override;
 
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */                             
+  virtual bool SetDefaultBooleanArray(llvm::StringRef key,
+                                      llvm::ArrayRef<int> defaultValue) override;
+
   /**
    * Returns the boolean array the key maps to. If the key does not exist or is
    * of different type, it will return the default value.
@@ -403,6 +437,15 @@ class NetworkTable : public ITable {
   virtual bool PutNumberArray(llvm::StringRef key,
                               llvm::ArrayRef<double> value) override;
 
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultNumberArray(llvm::StringRef key,
+                                     llvm::ArrayRef<double> defaultValue) override;
+
   /**
    * Returns the number array the key maps to. If the key does not exist or is
    * of different type, it will return the default value.
@@ -426,6 +469,15 @@ class NetworkTable : public ITable {
   virtual bool PutStringArray(llvm::StringRef key,
                               llvm::ArrayRef<std::string> value) override;
 
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultStringArray(llvm::StringRef key, 
+                                     llvm::ArrayRef<std::string> defaultValue) override;
+
   /**
    * Returns the string array the key maps to. If the key does not exist or is
    * of different type, it will return the default value.
@@ -448,6 +500,15 @@ class NetworkTable : public ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutRaw(llvm::StringRef key, llvm::StringRef value) override;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultRaw(llvm::StringRef key, 
+                             llvm::StringRef defaultValue) override;
 
   /**
    * Returns the raw value (byte array) the key maps to. If the key does not
@@ -471,6 +532,15 @@ class NetworkTable : public ITable {
    * @return False if the table key already exists with a different type
    */
   bool PutValue(llvm::StringRef key, std::shared_ptr<nt::Value> value) override;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultValue(llvm::StringRef key,
+                               std::shared_ptr<nt::Value> defaultValue) override;
 
   /**
    * Gets the value associated with a key as an object

--- a/include/ntcore_c.h
+++ b/include/ntcore_c.h
@@ -174,6 +174,19 @@ struct NT_RpcCallInfo {
  */
 void NT_GetEntryValue(const char *name, size_t name_len,
                       struct NT_Value *value);
+                      
+/** Set Default Entry Value.
+ * Returns copy of current entry value if it exists.
+ * Otherwise, sets passed in value, and returns set value.
+ * Note that one of the type options is "unassigned".
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_value     value to be set if name does not exist
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryValue(const char* name, size_t name_len,
+                            const struct NT_Value *default_value);
 
 /** Set Entry Value.
  * Sets new entry value.  If type of new value differs from the type of the
@@ -801,6 +814,107 @@ double *NT_GetEntryDoubleArray(const char *name, size_t name_len,
 NT_String *NT_GetEntryStringArray(const char *name, size_t name_len,
                                   unsigned long long *last_change,
                                   size_t *arr_size);
+
+/* Set Default Values */
+
+/** Set Default Entry Boolean.
+ * Sets the default for the specified key to be a boolean.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_boolean     value to be set if name does not exist
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryBoolean(const char *name, size_t name_len,
+                              int default_boolean);
+
+/** Set Default Entry Double.
+ * Sets the default for the specified key.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_double     value to be set if name does not exist
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryDouble(const char *name, size_t name_len,
+                             double default_double);
+
+/** Set Default Entry String.
+ * Sets the default for the specified key.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_value     value to be set if name does not exist
+ * @param default_len       length of value
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryString(const char *name, size_t name_len,
+                             const char *default_value, size_t default_len);
+
+/** Set Default Entry Raw.
+ * Sets the default for the specified key.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_value     value to be set if name does not exist
+ * @param default_len       length of value array
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryRaw(const char *name, size_t name_len,
+                          const char *default_value, size_t default_len);
+
+/** Set Default Entry Boolean Array.
+ * Sets the default for the specified key.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_value     value to be set if name does not exist
+ * @param default_size      size of value array
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryBooleanArray(const char *name, size_t name_len,
+                                   const int *default_value, 
+                                   size_t default_size);
+
+/** Set Default Entry Double Array.
+ * Sets the default for the specified key.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_value     value to be set if name does not exist
+ * @param default_size      size of value array
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryDoubleArray(const char *name, size_t name_len,
+                                  const double *default_value, 
+                                  size_t default_size);
+
+/** Set Default Entry String Array.
+ * Sets the default for the specified key.
+ * If key exists with same type, does not set value. Otherwise
+ * sets value to the default.
+ *
+ * @param name      entry name (UTF-8 string)
+ * @param name_len  length of name in bytes
+ * @param default_value     value to be set if name does not exist
+ * @param default_size      size of value array
+ * @return 0 on error (value not set), 1 on success
+ */
+int NT_SetDefaultEntryStringArray(const char *name, size_t name_len,
+                                  const struct NT_String* default_value,
+                                  size_t default_size);
 
 /* Entry Value Setters */
 

--- a/include/ntcore_cpp.h
+++ b/include/ntcore_cpp.h
@@ -96,6 +96,17 @@ struct RpcCallInfo {
  */
 std::shared_ptr<Value> GetEntryValue(StringRef name);
 
+/** Set Default Entry Value
+ * Returns copy of current entry value if it exists.
+ * Otherwise, sets passed in value, and returns set value.
+ * Note that one of the type options is "unassigned".
+ * 
+ * @param name      entry name (UTF-8 string)
+ * @param value     value to be set if name does not exist
+ * @return False on error (value not set), True on success
+ */
+bool SetDefaultEntryValue(StringRef name, std::shared_ptr<Value> value);
+
 /** Set Entry Value.
  * Sets new entry value.  If type of new value differs from the type of the
  * currently stored entry, returns error and does not update value.

--- a/include/tables/ITable.h
+++ b/include/tables/ITable.h
@@ -143,6 +143,15 @@ class ITable {
    * does not exist
    */
   virtual std::shared_ptr<nt::Value> GetValue(llvm::StringRef key) const = 0;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultValue(llvm::StringRef key,
+                               std::shared_ptr<nt::Value> defaultValue) = 0;
 
   /**
    * Put a value in the table
@@ -162,6 +171,14 @@ class ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutNumber(llvm::StringRef key, double value) = 0;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultNumber(llvm::StringRef key, double defaultValue) = 0;
 
   /**
    * Gets the number associated with the given name.
@@ -195,6 +212,15 @@ class ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutString(llvm::StringRef key, llvm::StringRef value) = 0;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultString(llvm::StringRef key, 
+                                llvm::StringRef defaultValue) = 0;
 
   /**
    * Gets the string associated with the given name.
@@ -233,6 +259,14 @@ class ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutBoolean(llvm::StringRef key, bool value) = 0;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultBoolean(llvm::StringRef key, bool defaultValue) = 0;
 
   /**
    * Gets the boolean associated with the given name.
@@ -271,6 +305,15 @@ class ITable {
    */
   virtual bool PutBooleanArray(llvm::StringRef key,
                                llvm::ArrayRef<int> value) = 0;
+                               
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */                             
+  virtual bool SetDefaultBooleanArray(llvm::StringRef key,
+                                      llvm::ArrayRef<int> defaultValue) = 0;
 
   /**
    * Returns the boolean array the key maps to. If the key does not exist or is
@@ -298,6 +341,15 @@ class ITable {
    */
   virtual bool PutNumberArray(llvm::StringRef key,
                               llvm::ArrayRef<double> value) = 0;
+                              
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultNumberArray(llvm::StringRef key,
+                                     llvm::ArrayRef<double> defaultValue) = 0;
 
   /**
    * Returns the number array the key maps to. If the key does not exist or is
@@ -321,6 +373,15 @@ class ITable {
    */
   virtual bool PutStringArray(llvm::StringRef key,
                               llvm::ArrayRef<std::string> value) = 0;
+                              
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultStringArray(llvm::StringRef key, 
+                                     llvm::ArrayRef<std::string> defaultValue) = 0;
 
   /**
    * Returns the string array the key maps to. If the key does not exist or is
@@ -343,6 +404,15 @@ class ITable {
    * @return False if the table key already exists with a different type
    */
   virtual bool PutRaw(llvm::StringRef key, llvm::StringRef value) = 0;
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doesn't exist.
+   * @returns False if the table key exists with a different type
+   */
+  virtual bool SetDefaultRaw(llvm::StringRef key, 
+                             llvm::StringRef defaultValue) = 0;
 
   /**
    * Returns the raw value (byte array) the key maps to. If the key does not

--- a/java/lib/NetworkTablesJNI.cpp
+++ b/java/lib/NetworkTablesJNI.cpp
@@ -917,6 +917,90 @@ JNIEXPORT jobjectArray JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkT
 
 /*
  * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultBoolean
+ * Signature: (Ljava/lang/String;Z)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultBoolean
+  (JNIEnv *env, jclass, jstring key, jboolean defaultValue)
+{
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key), 
+                                  nt::Value::MakeBoolean(defaultValue != JNI_FALSE));
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultDouble
+ * Signature: (Ljava/lang/String;D)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultDouble
+  (JNIEnv *env, jclass, jstring key, jdouble defaultValue)
+{
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key),
+                                  nt::Value::MakeDouble(defaultValue));
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultString
+ * Signature: (Ljava/lang/String;Ljava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultString
+  (JNIEnv *env, jclass, jstring key, jstring defaultValue)
+{
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key), 
+                                  nt::Value::MakeString(JavaStringRef(env, defaultValue)));
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultRaw
+ * Signature: (Ljava/lang/String;[B)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultRaw
+  (JNIEnv *env, jclass, jstring key, jbyteArray defaultValue)
+{
+  auto v = FromJavaRaw(env, defaultValue);
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key), v);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultBooleanArray
+ * Signature: (Ljava/lang/String;[Z)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultBooleanArray
+  (JNIEnv *env, jclass, jstring key, jbooleanArray defaultValue)
+{
+  auto v = FromJavaBooleanArray(env, defaultValue);
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key), v);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultDoubleArray
+ * Signature: (Ljava/lang/String;[D)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultDoubleArray
+  (JNIEnv *env, jclass, jstring key, jdoubleArray defaultValue)
+{
+  auto v = FromJavaDoubleArray(env, defaultValue);
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key), v);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
+ * Method:    setDefaultStringArray
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_networktables_NetworkTablesJNI_setDefaultStringArray
+  (JNIEnv *env, jclass, jstring key, jobjectArray defaultValue)
+{
+  auto v = FromJavaStringArray(env, defaultValue);
+  return nt::SetDefaultEntryValue(JavaStringRef(env, key), v);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_networktables_NetworkTablesJNI
  * Method:    setEntryFlags
  * Signature: (Ljava/lang/String;I)V
  */

--- a/java/src/edu/wpi/first/wpilibj/networktables/NetworkTable.java
+++ b/java/src/edu/wpi/first/wpilibj/networktables/NetworkTable.java
@@ -502,6 +502,14 @@ public class NetworkTable implements ITable, IRemote {
   public boolean putNumber(String key, double value) {
     return NetworkTablesJNI.putDouble(path + PATH_SEPARATOR + key, value);
   }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultNumber(String key, double defaultValue) {
+    return NetworkTablesJNI.setDefaultDouble(path + PATH_SEPARATOR + key,
+                                             defaultValue);
+  }
 
   /**
    * {@inheritDoc}
@@ -529,6 +537,14 @@ public class NetworkTable implements ITable, IRemote {
   public boolean putString(String key, String value) {
     return NetworkTablesJNI.putString(path + PATH_SEPARATOR + key, value);
   }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultString(String key, String defaultValue) {
+    return NetworkTablesJNI.setDefaultString(path + PATH_SEPARATOR + key,
+                                             defaultValue);
+  }
 
   /**
    * {@inheritDoc}
@@ -555,6 +571,14 @@ public class NetworkTable implements ITable, IRemote {
   @Override
   public boolean putBoolean(String key, boolean value) {
     return NetworkTablesJNI.putBoolean(path + PATH_SEPARATOR + key, value);
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultBoolean(String key, boolean defaultValue) {
+    return NetworkTablesJNI.setDefaultBoolean(path + PATH_SEPARATOR + key,
+                                              defaultValue);
   }
 
   /**
@@ -590,6 +614,22 @@ public class NetworkTable implements ITable, IRemote {
   @Override
   public boolean putBooleanArray(String key, Boolean[] value) {
     return putBooleanArray(key, toNative(value));
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultBooleanArray(String key, boolean[] defaultValue) {
+    return NetworkTablesJNI.setDefaultBooleanArray(path + PATH_SEPARATOR + key,
+                                                   defaultValue);
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultBooleanArray(String key, Boolean[] defaultValue) {
+    return NetworkTablesJNI.setDefaultBooleanArray(path + PATH_SEPARATOR + key,
+                                                   toNative(defaultValue));
   }
 
   /**
@@ -638,6 +678,22 @@ public class NetworkTable implements ITable, IRemote {
   public boolean putNumberArray(String key, Double[] value) {
     return putNumberArray(key, toNative(value));
   }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultNumberArray(String key, double[] defaultValue) {
+    return NetworkTablesJNI.setDefaultDoubleArray(path + PATH_SEPARATOR + key,
+                                                  defaultValue);
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultNumberArray(String key, Double[] defaultValue) {
+    return NetworkTablesJNI.setDefaultDoubleArray(path + PATH_SEPARATOR + key,
+                                                  toNative(defaultValue));
+  }
 
   /**
    * {@inheritDoc}
@@ -677,7 +733,15 @@ public class NetworkTable implements ITable, IRemote {
   public boolean putStringArray(String key, String[] value) {
     return NetworkTablesJNI.putStringArray(path + PATH_SEPARATOR + key, value);
   }
-
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultStringArray(String key, String[] defaultValue) {
+    return NetworkTablesJNI.setDefaultStringArray(path + PATH_SEPARATOR + key,
+                                                  defaultValue);
+  }
+  
   /**
    * {@inheritDoc}
    * @deprecated This exception-raising method has been replaced by the
@@ -703,6 +767,14 @@ public class NetworkTable implements ITable, IRemote {
   @Override
   public boolean putRaw(String key, byte[] value) {
     return NetworkTablesJNI.putRaw(path + PATH_SEPARATOR + key, value);
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public boolean setDefaultRaw(String key, byte[] defaultValue) {
+    return NetworkTablesJNI.setDefaultRaw(path + PATH_SEPARATOR + key,
+                                          defaultValue);
   }
 
   /**

--- a/java/src/edu/wpi/first/wpilibj/networktables/NetworkTablesJNI.java
+++ b/java/src/edu/wpi/first/wpilibj/networktables/NetworkTablesJNI.java
@@ -106,6 +106,14 @@ public class NetworkTablesJNI {
   public static native double[] getDoubleArray(String key, double[] defaultValue);
   public static native String[] getStringArray(String key, String[] defaultValue);
 
+  public static native boolean setDefaultBoolean(String key, boolean defaultValue);
+  public static native boolean setDefaultDouble(String key, double defaultValue);
+  public static native boolean setDefaultString(String key, String defaultValue);
+  public static native boolean setDefaultRaw(String key, byte[] defaultValue);
+  public static native boolean setDefaultBooleanArray(String key, boolean[] defaultValue);
+  public static native boolean setDefaultDoubleArray(String key, double[] defaultValue);
+  public static native boolean setDefaultStringArray(String key, String[] defaultValue);
+
   public static native void setEntryFlags(String key, int flags);
   public static native int getEntryFlags(String key);
 

--- a/java/src/edu/wpi/first/wpilibj/tables/ITable.java
+++ b/java/src/edu/wpi/first/wpilibj/tables/ITable.java
@@ -165,6 +165,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putNumber(String key, double value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultNumber(String key, double defaultValue);
+  
   /**
    * Returns the number the key maps to.
    * @param key the key to look up
@@ -193,6 +202,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putString(String key, String value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultString(String key, String defaultValue);
+  
   /**
    * Returns the string the key maps to.
    * @param key the key to look up
@@ -221,6 +239,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putBoolean(String key, boolean value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultBoolean(String key, boolean defaultValue);
+  
   /**
    * Returns the boolean the key maps to.
    * @param key the key to look up
@@ -249,6 +276,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putBooleanArray(String key, boolean[] value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultBooleanArray(String key, boolean[] defaultValue);
+  
   /**
    * Put a boolean array in the table
    * @param key the key to be assigned to
@@ -256,6 +292,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putBooleanArray(String key, Boolean[] value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultBooleanArray(String key, Boolean[] defaultValue);
+  
   /**
    * Returns the boolean array the key maps to.
    * @param key the key to look up
@@ -293,6 +338,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putNumberArray(String key, double[] value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultNumberArray(String key, double[] defaultValue);
+  
   /**
    * Put a number array in the table
    * @param key the key to be assigned to
@@ -300,6 +354,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putNumberArray(String key, Double[] value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultNumberArray(String key, Double[] defaultValue);
+  
   /**
    * Returns the number array the key maps to.
    * @param key the key to look up
@@ -337,6 +400,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putStringArray(String key, String[] value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultStringArray(String key, String[] defaultValue);
+  
   /**
    * Returns the string array the key maps to.
    * @param key the key to look up
@@ -365,6 +437,15 @@ public interface ITable {
    * @return False if the table key already exists with a different type
    */
   public boolean putRaw(String key, byte[] value);
+  
+  /** 
+   * Gets the current value in the table, setting it if it does not exist.
+   * @param key the key
+   * @param defaultValue the default value to set if key doens't exist.
+   * @return False if the table key exists with a different type
+   */
+  public boolean setDefaultRaw(String key, byte[] defaultValue);
+  
   /**
    * Put a raw value (bytes from a byte buffer) in the table
    * @param key the key to be assigned to

--- a/ntcore.def
+++ b/ntcore.def
@@ -82,6 +82,15 @@ NT_SetRpcServerOnStart @84
 NT_SetRpcServerOnExit @85
 NT_StartClientMulti @86
 
+NT_SetDefaultEntryValue @87
+NT_SetDefaultEntryBoolean @88
+NT_SetDefaultEntryDouble @89
+NT_SetDefaultEntryString @90
+NT_SetDefaultEntryRaw @91
+NT_SetDefaultEntryBooleanArray @92
+NT_SetDefaultEntryDoubleArray @93
+NT_SetDefaultEntryStringArray @94
+
 ; JNI functions
 JNI_OnLoad
 JNI_OnUnload

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -67,6 +67,7 @@ class Storage {
   // User functions.  These are the actual implementations of the corresponding
   // user API functions in ntcore_cpp.
   std::shared_ptr<Value> GetEntryValue(StringRef name) const;
+  bool SetDefaultEntryValue(StringRef name, std::shared_ptr<Value> value);
   bool SetEntryValue(StringRef name, std::shared_ptr<Value> value);
   void SetEntryTypeValue(StringRef name, std::shared_ptr<Value> value);
   void SetEntryFlags(StringRef name, unsigned int flags);

--- a/src/networktables/NetworkTable.cpp
+++ b/src/networktables/NetworkTable.cpp
@@ -305,6 +305,13 @@ bool NetworkTable::PutNumber(StringRef key, double value) {
   return nt::SetEntryValue(path, nt::Value::MakeDouble(value));
 }
 
+bool NetworkTable::SetDefaultNumber(StringRef key, double defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeDouble(defaultValue));
+}
+
 double NetworkTable::GetNumber(StringRef key) const {
   llvm::SmallString<128> path(m_path);
   path += PATH_SEPARATOR_CHAR;
@@ -330,6 +337,13 @@ bool NetworkTable::PutString(StringRef key, StringRef value) {
   path += PATH_SEPARATOR_CHAR;
   path += key;
   return nt::SetEntryValue(path, nt::Value::MakeString(value));
+}
+
+bool NetworkTable::SetDefaultString(StringRef key, StringRef defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeString(defaultValue));
 }
 
 std::string NetworkTable::GetString(StringRef key) const {
@@ -360,6 +374,13 @@ bool NetworkTable::PutBoolean(StringRef key, bool value) {
   return nt::SetEntryValue(path, nt::Value::MakeBoolean(value));
 }
 
+bool NetworkTable::SetDefaultBoolean(StringRef key, bool defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeBoolean(defaultValue));
+}
+
 bool NetworkTable::GetBoolean(StringRef key) const {
   llvm::SmallString<128> path(m_path);
   path += PATH_SEPARATOR_CHAR;
@@ -388,6 +409,14 @@ bool NetworkTable::PutBooleanArray(llvm::StringRef key,
   return nt::SetEntryValue(path, nt::Value::MakeBooleanArray(value));
 }
 
+bool NetworkTable::SetDefaultBooleanArray(StringRef key,
+                                          llvm::ArrayRef<int> defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeBooleanArray(defaultValue));
+}
+
 std::vector<int> NetworkTable::GetBooleanArray(
     llvm::StringRef key, llvm::ArrayRef<int> defaultValue) const {
   llvm::SmallString<128> path(m_path);
@@ -405,6 +434,14 @@ bool NetworkTable::PutNumberArray(llvm::StringRef key,
   path += PATH_SEPARATOR_CHAR;
   path += key;
   return nt::SetEntryValue(path, nt::Value::MakeDoubleArray(value));
+}
+
+bool NetworkTable::SetDefaultNumberArray(StringRef key,
+                                         llvm::ArrayRef<double> defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeDoubleArray(defaultValue));
 }
 
 std::vector<double> NetworkTable::GetNumberArray(
@@ -426,6 +463,14 @@ bool NetworkTable::PutStringArray(llvm::StringRef key,
   return nt::SetEntryValue(path, nt::Value::MakeStringArray(value));
 }
 
+bool NetworkTable::SetDefaultStringArray(StringRef key,
+                                         llvm::ArrayRef<std::string> defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeStringArray(defaultValue));
+}
+
 std::vector<std::string> NetworkTable::GetStringArray(
     llvm::StringRef key, llvm::ArrayRef<std::string> defaultValue) const {
   llvm::SmallString<128> path(m_path);
@@ -444,6 +489,14 @@ bool NetworkTable::PutRaw(llvm::StringRef key, llvm::StringRef value) {
   return nt::SetEntryValue(path, nt::Value::MakeRaw(value));
 }
 
+bool NetworkTable::SetDefaultRaw(StringRef key,
+                                 StringRef defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, nt::Value::MakeRaw(defaultValue));
+}
+
 std::string NetworkTable::GetRaw(llvm::StringRef key,
                                  llvm::StringRef defaultValue) const {
   llvm::SmallString<128> path(m_path);
@@ -460,6 +513,14 @@ bool NetworkTable::PutValue(StringRef key, std::shared_ptr<nt::Value> value) {
   path += PATH_SEPARATOR_CHAR;
   path += key;
   return nt::SetEntryValue(path, value);
+}
+
+bool NetworkTable::SetDefaultValue(StringRef key,
+                                   std::shared_ptr<nt::Value> defaultValue) {
+  llvm::SmallString<128> path(m_path);
+  path += PATH_SEPARATOR_CHAR;
+  path += key;
+  return nt::SetDefaultEntryValue(path, defaultValue);
 }
 
 std::shared_ptr<nt::Value> NetworkTable::GetValue(StringRef key) const {

--- a/src/ntcore_c.cpp
+++ b/src/ntcore_c.cpp
@@ -124,6 +124,12 @@ void NT_GetEntryValue(const char *name, size_t name_len,
   ConvertToC(*v, value);
 }
 
+int NT_SetDefaultEntryValue(const char* name, size_t name_len,
+                            const struct NT_Value *set_value) {
+    return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                    ConvertFromC(*set_value));
+}
+
 int NT_SetEntryValue(const char *name, size_t name_len,
                      const struct NT_Value *value) {
   return nt::SetEntryValue(StringRef(name, name_len), ConvertFromC(*value));
@@ -699,6 +705,57 @@ NT_String *NT_GetValueStringArray(const struct NT_Value *value,
     std::memcpy(arr[i].str, value->data.arr_string.arr[i].str, len + 1);
   }
   return arr;
+}
+
+int NT_SetDefaultEntryBoolean(const char *name, size_t name_len,
+                              int default_boolean) {
+  return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                  Value::MakeBoolean(default_boolean != 0));
+}
+
+int NT_SetDefaultEntryDouble(const char *name, size_t name_len,
+                             double default_double) {
+  return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                  Value::MakeDouble(default_double));
+}
+
+int NT_SetDefaultEntryString(const char *name, size_t name_len,
+                             const char *default_value, size_t default_len) {
+  return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                  Value::MakeString(StringRef(default_value,
+                                                    default_len)));
+}
+
+int NT_SetDefaultEntryRaw(const char *name, size_t name_len,
+                          const char *default_value, size_t default_len) {
+  return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                  Value::MakeString(StringRef(default_value,
+                                                    default_len)));
+}
+
+int NT_SetDefaultEntryBooleanArray(const char *name, size_t name_len,
+                                   const int *default_value, 
+                                   size_t default_size) {
+  return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                  Value::MakeBooleanArray(llvm::makeArrayRef(default_value, default_size)));
+}
+
+int NT_SetDefaultEntryDoubleArray(const char *name, size_t name_len, const double *default_value,
+                                  size_t default_size) {
+  return nt::SetDefaultEntryValue(StringRef(name, name_len),
+                                  Value::MakeDoubleArray(llvm::makeArrayRef(default_value, default_size)));
+}
+
+int NT_SetDefaultEntryStringArray(const char *name, size_t name_len,
+                                  const struct NT_String* default_value,
+                                  size_t default_size) {
+  std::vector<std::string> vec;
+  vec.reserve(default_size);
+  for (size_t i = 0; i < default_size; ++i) 
+    vec.push_back(ConvertFromC(default_value[i]));
+  
+  return nt::SetDefaultEntryValue(StringRef(name, name_len), 
+                                  Value::MakeStringArray(std::move(vec)));
 }
 
 int NT_GetEntryBoolean(const char *name, size_t name_len,

--- a/src/ntcore_cpp.cpp
+++ b/src/ntcore_cpp.cpp
@@ -29,6 +29,10 @@ std::shared_ptr<Value> GetEntryValue(StringRef name) {
   return Storage::GetInstance().GetEntryValue(name);
 }
 
+bool SetDefaultEntryValue(StringRef name, std::shared_ptr<Value> value) {
+  return Storage::GetInstance().SetDefaultEntryValue(name, value);
+}
+
 bool SetEntryValue(StringRef name, std::shared_ptr<Value> value) {
   return Storage::GetInstance().SetEntryValue(name, value);
 }


### PR DESCRIPTION
There was no way to atomically check for a key in the table,
and then setting if it if non existant. Back before persistent
this was not a problem, however now it is, as its possible for
values to be added before team's robot programs start. This makes
the old method of calling Put**\* methods in RobotInit invalid.
This adds SetDefault methods, which do this atomically.

Discussed in #53 
