### PR TITLE
Fixes .gitignore ignoring needed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 .vs/
 *.def
+!ntcore.def
 *.opensdf
 *.vcxproj
 *.vcxproj.user
@@ -40,6 +41,7 @@
 # Build directories
 /.gradle
 /build*
+!build.gradle
 /native
 /arm
 /gmock/build


### PR DESCRIPTION
ntcore.def and build.gradle were being ignored, which could cause issues
if those files ever got deleted.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/ntcore/68)

<!-- Reviewable:end -->
