### PR TITLE
Changes remote_name to remote_ip

### DIFF
--- a/include/ntcore_c.h
+++ b/include/ntcore_c.h
@@ -120,7 +120,7 @@ struct NT_EntryInfo {
 /** NetworkTables Connection Information */
 struct NT_ConnectionInfo {
   struct NT_String remote_id;
-  char *remote_name;
+  struct NT_String remote_ip;
   unsigned int remote_port;
   unsigned long long last_update;
   unsigned int protocol_version;
@@ -185,7 +185,7 @@ void NT_GetEntryValue(const char *name, size_t name_len,
  * @param default_value     value to be set if name does not exist
  * @return 0 on error (value not set), 1 on success
  */
-int NT_SetDefaultEntryValue(const char* name, size_t name_len,
+int NT_SetDefaultEntryValue(const char *name, size_t name_len,
                             const struct NT_Value *default_value);
 
 /** Set Entry Value.

--- a/include/ntcore_cpp.h
+++ b/include/ntcore_cpp.h
@@ -42,7 +42,7 @@ struct EntryInfo {
 /** NetworkTables Connection Information */
 struct ConnectionInfo {
   std::string remote_id;
-  std::string remote_name;
+  std::string remote_ip;
   unsigned int remote_port;
   unsigned long long last_update;
   unsigned int protocol_version;

--- a/java/lib/NetworkTablesJNI.cpp
+++ b/java/lib/NetworkTablesJNI.cpp
@@ -428,9 +428,9 @@ static jobject ToJavaObject(JNIEnv *env, const nt::ConnectionInfo &info) {
       env->GetMethodID(connectionInfoCls, "<init>",
                        "(Ljava/lang/String;Ljava/lang/String;IJI)V");
   JavaLocal<jstring> remote_id(env, ToJavaString(env, info.remote_id));
-  JavaLocal<jstring> remote_name(env, ToJavaString(env, info.remote_name));
+  JavaLocal<jstring> remote_ip(env, ToJavaString(env, info.remote_ip));
   return env->NewObject(connectionInfoCls, constructor, remote_id.obj(),
-                        remote_name.obj(), (jint)info.remote_port,
+                        remote_ip.obj(), (jint)info.remote_port,
                         (jlong)info.last_update, (jint)info.protocol_version);
 }
 

--- a/java/src/edu/wpi/first/wpilibj/networktables/ConnectionInfo.java
+++ b/java/src/edu/wpi/first/wpilibj/networktables/ConnectionInfo.java
@@ -2,14 +2,14 @@ package edu.wpi.first.wpilibj.networktables;
 
 public class ConnectionInfo {
   public final String remote_id;
-  public final String remote_name;
+  public final String remote_ip;
   public final int remote_port;
   public final long last_update;
   public final int protocol_version;
 
-  ConnectionInfo(String remote_id, String remote_name, int remote_port, long last_update, int protocol_version) {
+  ConnectionInfo(String remote_id, String remote_ip, int remote_port, long last_update, int protocol_version) {
     this.remote_id = remote_id;
-    this.remote_name = remote_name;
+    this.remote_ip = remote_ip;
     this.remote_port = remote_port;
     this.last_update = last_update;
     this.protocol_version = protocol_version;

--- a/src/ntcore_c.cpp
+++ b/src/ntcore_c.cpp
@@ -32,7 +32,7 @@ static void ConvertToC(const EntryInfo& in, NT_EntryInfo* out) {
 
 static void ConvertToC(const ConnectionInfo& in, NT_ConnectionInfo* out) {
   ConvertToC(in.remote_id, &out->remote_id);
-  ConvertToC(in.remote_name, &out->remote_name);
+  ConvertToC(in.remote_ip, &out->remote_ip);
   out->remote_port = in.remote_port;
   out->last_update = in.last_update;
   out->protocol_version = in.protocol_version;
@@ -74,7 +74,7 @@ static void ConvertToC(const RpcCallInfo& in, NT_RpcCallInfo* out) {
 
 static void DisposeConnectionInfo(NT_ConnectionInfo *info) {
   std::free(info->remote_id.str);
-  std::free(info->remote_name);
+  std::free(info->remote_ip.str);
 }
 
 static void DisposeEntryInfo(NT_EntryInfo *info) {


### PR DESCRIPTION
Was confusing, as remote_name seemed like a name but wasn't.
Also changes remote_ip in the C api to use an NT_String
