### PR TITLE
Adds ConnectionInfo to Rpc callback

### DIFF
--- a/include/ntcore_c.h
+++ b/include/ntcore_c.h
@@ -311,7 +311,8 @@ void NT_SetRpcServerOnExit(void (*on_exit)(void *data), void *data);
 
 typedef char *(*NT_RpcCallback)(void *data, const char *name, size_t name_len,
                                 const char *params, size_t params_len,
-                                size_t *results_len);
+                                size_t *results_len, 
+                                const struct NT_ConnectionInfo* conn_info);
 
 void NT_CreateRpc(const char *name, size_t name_len, const char *def,
                   size_t def_len, void *data, NT_RpcCallback callback);

--- a/include/ntcore_cpp.h
+++ b/include/ntcore_cpp.h
@@ -224,7 +224,8 @@ constexpr double kTimeout_Indefinite = -1;
 void SetRpcServerOnStart(std::function<void()> on_start);
 void SetRpcServerOnExit(std::function<void()> on_exit);
 
-typedef std::function<std::string(StringRef name, StringRef params)>
+typedef std::function<std::string(StringRef name, StringRef params, 
+                                  const ConnectionInfo& conn_info)>
     RpcCallback;
 
 void CreateRpc(StringRef name, StringRef def, RpcCallback callback);

--- a/src/RpcServer.h
+++ b/src/RpcServer.h
@@ -41,7 +41,8 @@ class RpcServer {
 
   void ProcessRpc(StringRef name, std::shared_ptr<Message> msg,
                   RpcCallback func, unsigned int conn_id,
-                  SendMsgFunc send_response);
+                  SendMsgFunc send_response,
+                  const ConnectionInfo& conn_info);
 
   bool PollRpc(bool blocking, RpcCallInfo* call_info);
   bool PollRpc(bool blocking, double time_out, RpcCallInfo* call_info);
@@ -56,18 +57,21 @@ class RpcServer {
 
   struct RpcCall {
     RpcCall(StringRef name_, std::shared_ptr<Message> msg_, RpcCallback func_,
-            unsigned int conn_id_, SendMsgFunc send_response_)
+            unsigned int conn_id_, SendMsgFunc send_response_,
+            const ConnectionInfo conn_info_)
         : name(name_),
           msg(msg_),
           func(func_),
           conn_id(conn_id_),
-          send_response(send_response_) {}
+          send_response(send_response_),
+          conn_info(conn_info_) {}
 
     std::string name;
     std::shared_ptr<Message> msg;
     RpcCallback func;
     unsigned int conn_id;
     SendMsgFunc send_response;
+    ConnectionInfo conn_info;
   };
 
   std::mutex m_mutex;

--- a/src/ntcore_c.cpp
+++ b/src/ntcore_c.cpp
@@ -234,12 +234,17 @@ void NT_CreateRpc(const char *name, size_t name_len, const char *def,
                   size_t def_len, void *data, NT_RpcCallback callback) {
   nt::CreateRpc(
       StringRef(name, name_len), StringRef(def, def_len),
-      [=](StringRef name, StringRef params) -> std::string {
+      [=](StringRef name, StringRef params, 
+          const ConnectionInfo& conn_info) -> std::string {
         size_t results_len;
+        NT_ConnectionInfo conn_c;
+        ConvertToC(conn_info, &conn_c);
         char* results_c = callback(data, name.data(), name.size(),
-                                   params.data(), params.size(), &results_len);
+                                   params.data(), params.size(), &results_len,
+                                   &conn_c);
         std::string results(results_c, results_len);
         std::free(results_c);
+        DisposeConnectionInfo(&conn_c);
         return results;
       });
 }

--- a/test/rpc_local.cpp
+++ b/test/rpc_local.cpp
@@ -4,7 +4,8 @@
 
 #include "ntcore.h"
 
-std::string callback1(nt::StringRef name, nt::StringRef params_str) {
+std::string callback1(nt::StringRef name, nt::StringRef params_str,
+                      const ConnectionInfo& conn_info) {
   auto params = nt::UnpackRpcValues(params_str, NT_DOUBLE);
   if (params.empty()) {
     std::fputs("empty params?\n", stderr);

--- a/test/rpc_speed.cpp
+++ b/test/rpc_speed.cpp
@@ -5,7 +5,8 @@
 
 #include "ntcore.h"
 
-std::string callback1(nt::StringRef name, nt::StringRef params_str) {
+std::string callback1(nt::StringRef name, nt::StringRef params_str,
+                      const ConnectionInfo& conn_info) {
   auto params = nt::UnpackRpcValues(params_str, NT_DOUBLE);
   if (params.empty()) {
     std::fputs("empty params?\n", stderr);


### PR DESCRIPTION
Only did the callback this time instead of the RpcCallInfo. I'll do that in a separate PR. This has been tested on both linux and windows to work properly
