### PR TITLE
Removes the native library from the RoboRIO Jar

### DIFF
--- a/java/java.gradle
+++ b/java/java.gradle
@@ -31,9 +31,11 @@ jar {
     model {
         binaries {
             withType(SharedLibraryBinarySpec) { binary ->
-                from(file(binary.sharedLibraryFile)) {
-                    into getPlatformPath(binary)
-                }
+                // Only include the native file if not cross compiling to the roboRIO
+                if (!project.isArm || project.hasProperty('compilerPrefix'))
+                    from(file(binary.sharedLibraryFile)) {
+                        into getPlatformPath(binary)
+                    }
             }
         }
     }

--- a/publish.gradle
+++ b/publish.gradle
@@ -47,7 +47,12 @@ publishing {
                 artifact nat.networktablesJavaSource
                 artifact nat.networktablesJavadoc
                 if (project.buildArm) {
-                    artifact project('arm:ntcore').jar
+                    def natArm = project('arm:ntcore')
+                    artifact natArm.jar
+                    // If the library is not embedded include it in the repo
+                    if (!project.hasProperty('compilerPrefix')) {
+                        artifact natArm.ntcoreZip
+                    }                   
                 }
 
                 if (project.hasProperty('makeDesktop')) {


### PR DESCRIPTION
Includes the native zip in the maven artifact as well.
