### PR TITLE
Add new ARM Toolchain, add toolchainpath to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ BUILD FAILED
 Total time: 2.441 secs
 ```
 
+If you have the Toolchain installed somewhere not on the System PATH, you can use the `toolChainPath` property to specify where the bin location of the toolchain is installed to, for example:
+
+```bash
+./gradlew :arm:build -PtoolChainPath=some/path/to/my/toolchain/bin
+```
+
 ## Testing
 By default, tests will be built for the x86 and x64 versions of ntcore, and will be run during any execution of the `build` or `publish` tasks. To skip building and running the tests, use the `-PwithoutTests` command line flag when running Gradle.
 

--- a/toolchains/arm.gradle
+++ b/toolchains/arm.gradle
@@ -2,18 +2,21 @@ ext.isArm = true
 ext.buildPlatform = 'arm'
 
 def compilerPrefix = project.hasProperty('compilerPrefix') ? project.compilerPrefix : 'arm-frc-linux-gnueabi-'
+def toolChainPath = project.hasProperty('toolChainPath') ? project.toolChainPath : null
 model {
     platforms {
-	arm {
-	    architecture 'arm'
-	    operatingSystem 'linux'
-	}
+        arm {
+            architecture 'arm'
+            operatingSystem 'linux'
+        }
     }
     toolChains {
-        gcc(Gcc) {
+        armGcc(Gcc) {
+            if (toolChainPath != null) path(toolChainPath)
             target("arm") {
                 // We use a custom-built cross compiler with the prefix arm-frc-linux-gnueabi-<util name>
                 // If this ever changes, the prefix will need to be changed here
+                cCompiler.executable = compilerPrefix + cCompiler.executable
                 cppCompiler.executable = compilerPrefix + cppCompiler.executable
                 linker.executable = compilerPrefix + linker.executable
                 assembler.executable = compilerPrefix + assembler.executable
@@ -35,35 +38,12 @@ model {
                 staticLibArchiver.executable = compilerPrefix + staticLibArchiver.executable
             }
         }
-        // Workaround for OS X. Macs for some reason want to use Xcode's gcc
-        // (which just wraps Clang), so we have to explicitly make it so
-        // that trying to compile with Clang will call gcc instead
-        macGcc(Clang) {
-            target('arm') {
-                // We use a custom-built cross compiler with the prefix arm-frc-linux-gnueabi-<util name>
-                // If this ever changes, the prefix will need to be changed here
-                cppCompiler.executable = compilerPrefix + 'g++'
-                linker.executable = compilerPrefix + 'g++'
-                assembler.executable = compilerPrefix + 'gcc'
-                // Gradle auto-adds the -m32 argument to the linker and compiler. Our compiler only supports
-                // arm, and doesn't understand this flag, so it is removed from both
-                cppCompiler.withArguments { args ->
-                    args << '-std=c++1y' << '-Wformat=2' << '-Wall' << '-Wextra' << '-Werror' << '-pedantic'
-                    args << '-Wno-psabi' << '-Wno-unused-parameter' << '-fPIC' << '-O0' << '-g3' << '-rdynamic'
-                    //TODO: When the compiler allows us to actually call deprecated functions from within
-                    // deprecated function, remove this line (this will cause calling deprecated functions
-                    // to be treated as a warning rather than an error).
-                    args << '-Wno-error=deprecated-declarations' << '-pthread'
-                    args.remove('-m32')
-                }
-                linker.withArguments { args ->
-                    args << '-rdynamic' << '-pthread'
-                    args.remove('-m32')
-                }
-                staticLibArchiver.executable = compilerPrefix + 'ar'
-            }
-        }
     }
+}
+
+ext.binTools = { tool ->
+    if (toolChainPath != null) return "${toolChainPath}/${compilerPrefix}${tool}"
+    return "${compilerPrefix}${tool}"
 }
 
 ext.setupReleaseDefines = { cppCompiler, linker ->
@@ -84,9 +64,9 @@ ext.debugStripSetup = {
                 def library = task.outputFile.absolutePath
                 def debugLibrary = task.outputFile.absolutePath + ".debug"
                 task.doLast {
-                    exec { commandLine "${compilerPrefix}objcopy", '--only-keep-debug', library, debugLibrary }
-                    exec { commandLine "${compilerPrefix}strip", '-g', library }
-                    exec { commandLine "${compilerPrefix}objcopy", "--add-gnu-debuglink=$debugLibrary", library }
+                    exec { commandLine binTools('objcopy'), '--only-keep-debug', library, debugLibrary }
+                    exec { commandLine binTools('strip'), '-g', library }
+                    exec { commandLine binTools('objcopy'), "--add-gnu-debuglink=$debugLibrary", library }
                 }
             }
         }
@@ -100,7 +80,7 @@ ext.checkNativeSymbols = { getSymbolFunc ->
             task.doLast {
                 def nmOutput = new ByteArrayOutputStream()
                 exec { 
-                    commandLine "${compilerPrefix}nm", library
+                    commandLine binTools('nm'), library
                     standardOutput nmOutput
                 }
                 // Remove '\r' so we can check for full string contents


### PR DESCRIPTION
This Pull Request is nearly identical to [allwpilib#405](https://github.com/wpilibsuite/allwpilib/pull/405)

In short, currently a hack exists in nt-core and many other WPILib Suite projects for the ARM / RoboRIO Cross Toolchain, specifically for Mac platforms. Gradle detects Mac GCC as a proxy to XCode Clang, so it sees it as not buildable unless a Clang target is also registered. The detection for this proxy is based on the output of `gcc`, not `g++`. As NT-Core does not declare a C Compiler Tool, but instead a C++ Compiler Tool, it defaults to system gcc. This PR fixes this hack and correctly identifies it as GCC and not Clang on OS X.

Furthermore, the `toolChainPath` property has been added to the project that allows the user to specify the Toolchain Path should it not be on the System PATH.

This PR is also partial preparation for the build system overhaul discussed [here](https://github.com/wpilibsuite/allwpilib/pull/405#issuecomment-267867080) for later in 2017 should the interest be there.

This PR has been tested on OS X El Capitan 10.11.6