### PR TITLE
Fixes TCPAcceptor able to use an empty string

### DIFF
--- a/wpiutil/src/tcpsockets/TCPAcceptor.cpp
+++ b/wpiutil/src/tcpsockets/TCPAcceptor.cpp
@@ -90,7 +90,7 @@ int TCPAcceptor::start() {
 #else
     int res = inet_pton(PF_INET, m_address.c_str(), &(address.sin_addr));
 #endif
-    if (res != 1) {
+    if (res != 1 && !m_address.empty()) {
       WPI_ERROR(m_logger, "could not resolve " << m_address << " address");
       return -1;
     }


### PR DESCRIPTION
@PeterJohnson this only changes the acceptor, since I don't think
TCPConnector needs to be able to support an empty string.