### PR TITLE
Removes all TCPAcceptor checks

### DIFF
--- a/wpiutil/src/tcpsockets/TCPAcceptor.cpp
+++ b/wpiutil/src/tcpsockets/TCPAcceptor.cpp
@@ -86,14 +86,10 @@ int TCPAcceptor::start() {
 #ifdef _WIN32
     llvm::SmallString<128> addr_copy(m_address);
     addr_copy.push_back('\0');
-    int res = InetPton(PF_INET, addr_copy.data(), &(address.sin_addr));
+    InetPton(PF_INET, addr_copy.data(), &(address.sin_addr));
 #else
-    int res = inet_pton(PF_INET, m_address.c_str(), &(address.sin_addr));
+    inet_pton(PF_INET, m_address.c_str(), &(address.sin_addr));
 #endif
-    if (res != 1 && !m_address.empty()) {
-      WPI_ERROR(m_logger, "could not resolve " << m_address << " address");
-      return -1;
-    }
   } else {
     address.sin_addr.s_addr = INADDR_ANY;
   }


### PR DESCRIPTION
Other fix doesn't fix, and this seems like a deeper issue in JStringRef
that I don't have time to fix. This will work around the issue for now.