### PR TITLE
Adds support for building separate armhf artifacts

### DIFF
--- a/ntcore.gradle
+++ b/ntcore.gradle
@@ -61,7 +61,12 @@ def ntcoreZipTask = { project ->
         group = 'WPILib'
         destinationDir = project.buildDir
         baseName = 'ntcore'
-        classifier = "${project.buildPlatform}"
+        if (project.isArm && project.hasProperty('compilerPrefix')
+            && project.hasProperty('armSuffix')) {
+            classifier = "${project.buildPlatform}${project.armSuffix}"
+        } else {
+            classifier = "${project.buildPlatform}"
+        }
         duplicatesStrategy = 'exclude'
 
         from(file('include')) {

--- a/wpiutil.gradle
+++ b/wpiutil.gradle
@@ -34,7 +34,12 @@ def wpiutilZipTask = { project ->
         group = 'WPILib'
         destinationDir = project.buildDir
         baseName = 'wpiutil'
-        classifier = "${project.buildPlatform}"
+        if (project.isArm && project.hasProperty('compilerPrefix')
+            && project.hasProperty('armSuffix')) {
+            classifier = "${project.buildPlatform}${project.armSuffix}"
+        } else {
+            classifier = "${project.buildPlatform}"
+        }
         duplicatesStrategy = 'exclude'
 
         from(file('wpiutil/include')) {


### PR DESCRIPTION
Currently if using a separate compiler prefix, it would get published to
the arm classifier. This modifies so there is now an armhf classifier
that is used if a separate compiler prefix is used.