### PR TITLE
Correct platform path for Linux on 32-bit Intel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext.getPlatformPath = { binary ->
         if (binary.targetPlatform.architecture.amd64) {
             return 'Linux/amd64'
         } else {
-            return 'Linux/' + binary.targetPlatform.architecture.name
+            return 'Linux/i386'
         }
     } else if (binary.targetPlatform.operatingSystem.windows) {
         if (binary.targetPlatform.architecture.amd64) {


### PR DESCRIPTION
Gradle needs to produce a platform path of "Linux/i386" when targeting a Linux 32-bit Intel platform. Otherwise, it doesn't match Java's os.name/os.arch when loading the ntcore library in NetworkTablesJNI.java. Windows uses "x86" but Linux uses "i386". (http://lopica.sourceforge.net/os.html)