### PR TITLE
Add dependency to jni task to fix 32 bit builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,17 +7,21 @@ build:
   verbosity: detailed
 
 build_script:
-  - gradlew.bat assemble --info -PbuildAll
+  - gradlew.bat tasks
 
 test_script:
 - cmd: >-
     SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 
-    gradlew.bat check --info -PbuildAll
+    gradlew.bat clean
+
+    gradlew.bat check --info
 
     SET JAVA_HOME=C:\Program Files (x86)\Java\jdk1.8.0
 
-    gradlew.bat check --info -PbuildAll
+    gradlew.bat clean
+
+    gradlew.bat check --info
 
 cache:
   - C:\Users\appveyor\.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ task nativeTestFilesJar(type: Jar) {
                     from(binary.sharedLibraryFile) {
                         into NativeUtils.getPlatformPath(binary)
                     }
+                    dependsOn binary.buildTask
                 }
             }
         }


### PR DESCRIPTION
Fixes #212
Also forces appveyor to test both 32 and 64 bit correctly.
assemble was removed because it would inadvertently cause a 3rd build.