### PR TITLE
Adds a runCpp task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,26 @@ model {
             }
         }
     }
+    tasks {
+        def c = $.components
+        project.tasks.create('runCpp', Exec) {
+            def found = false
+            c.each {
+                if (it in NativeExecutableSpec && it.name == 'ntcoreExe') {
+                    it.binaries.each {
+                        if (!found) {
+                            def arch = it.targetPlatform.architecture.name
+                            if (arch == 'x86-64' || arch == 'x86') {
+                                dependsOn it.tasks.install
+                                commandLine it.tasks.install.runScript
+                                found = true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 apply from: 'publish.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ model {
             ext = 'zip'
             version = '+'
             sharedConfigs = [ ntcore: [],
-                              ntcoreExe: [],
+                              ntcoreDev: [],
                               ntcoreTestingBaseTest: [] ]
             staticConfigs = [ ntcoreJNI: [] ]
         }
@@ -159,7 +159,7 @@ model {
             }
         }
         if (!project.hasProperty('skipTestExe')) {
-            ntcoreExe(NativeExecutableSpec) {
+            ntcoreDev(NativeExecutableSpec) {
                 sources {
                     cpp {
                         lib library: "ntcore"
@@ -205,7 +205,7 @@ model {
         project.tasks.create('runCpp', Exec) {
             def found = false
             c.each {
-                if (it in NativeExecutableSpec && it.name == 'ntcoreExe') {
+                if (it in NativeExecutableSpec && it.name == 'ntcoreDev') {
                     it.binaries.each {
                         if (!found) {
                             def arch = it.targetPlatform.architecture.name


### PR DESCRIPTION
We don't have an easy way to detect current platform, so it just looks
for the first x86 or x86-64 runtime it finds. Since those are the arches
unit tests run on, it should be fine.